### PR TITLE
Add emscripten_clipboard_deinit to unregister event listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ emscripten_clipboard_set(&clipboard, "Hello, World!");
 
 // Retrieve the contents. This can be iffy, due to browser permissions.
 const char* text = emscripten_clipboard_get(&clipboard);
+
+// Deinitialize the clipboard and unregister event listeners.
+emscripten_clipboard_deinit(&clipboard);
 ```
 
 ## API

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ const char* text = emscripten_clipboard_get(&clipboard);
 void emscripten_clipboard_init(emscripten_clipboard* clipboard);
 const char* emscripten_clipboard_get(emscripten_clipboard* clipboard);
 void emscripten_clipboard_set(emscripten_clipboard* clipboard, const char* text);
+void emscripten_clipboard_deinit(emscripten_clipboard* clipboard);
 ```
 
 ## Dependencies

--- a/emscripten_clipboard.h
+++ b/emscripten_clipboard.h
@@ -91,6 +91,19 @@ EMSCRIPTEN_CLIPBOARD_API const char* emscripten_clipboard_get(emscripten_clipboa
  */
 EMSCRIPTEN_CLIPBOARD_API void emscripten_clipboard_set(emscripten_clipboard* clipboard, const char* text);
 
+/**
+ * Deinitializes a clipboard object, and unregisters the clipboard events.
+ *
+ * @code
+ * emscripten_clipboard_deinit(&clipboard);
+ * @endcode
+ *
+ * @param clipboard The clipboard object to deinitialize.
+ *
+ * @see emscripten_clipboard_init()
+ */
+EMSCRIPTEN_CLIPBOARD_API void emscripten_clipboard_deinit(emscripten_clipboard* clipboard);
+
 #endif  // EMSCRIPTEN_CLIPBOARD_H__
 
 #ifdef EMSCRIPTEN_CLIPBOARD_IMPLEMENTATION
@@ -127,8 +140,21 @@ EM_JS(void, emscripten_clipboard__register, (void* clipboard, const char* text, 
         }
         Module.HEAPU8[text + i] = 0;
     }
+    if (!Module._emscripten_clipboard_handlers) {
+        Module._emscripten_clipboard_handlers = {};
+    }
+    Module._emscripten_clipboard_handlers[clipboard] = emscripten_clipboard__change_event;
     document.addEventListener('clipboardchange', emscripten_clipboard__change_event);
     document.addEventListener('paste', emscripten_clipboard__change_event);
+})
+
+EM_JS(void, emscripten_clipboard__unregister, (void* clipboard), {
+    if (Module._emscripten_clipboard_handlers && Module._emscripten_clipboard_handlers[clipboard]) {
+        const handler = Module._emscripten_clipboard_handlers[clipboard];
+        document.removeEventListener('clipboardchange', handler);
+        document.removeEventListener('paste', handler);
+        delete Module._emscripten_clipboard_handlers[clipboard];
+    }
 })
 
 EMSCRIPTEN_CLIPBOARD_API const char* emscripten_clipboard_get(emscripten_clipboard* clipboard) {
@@ -175,6 +201,16 @@ EMSCRIPTEN_CLIPBOARD_API void emscripten_clipboard_init(emscripten_clipboard* cl
 
     // Register the clipboard events for the object.
     emscripten_clipboard__register(clipboard, clipboard->text, EMSCRIPTEN_CLIPBOARD_MAX);
+}
+
+EMSCRIPTEN_CLIPBOARD_API void emscripten_clipboard_deinit(emscripten_clipboard* clipboard) {
+    if (clipboard == NULL) {
+        return;
+    }
+
+    emscripten_clipboard__unregister(clipboard);
+    clipboard->text[0] = '\0';
+    clipboard->user_data = NULL;
 }
 
 #endif  // EMSCRIPTEN_CLIPBOARD_IMPLEMENTATION_ONCE

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "description": "emscripten_clipboard: Clipboard API for Emscripten.",
   "main": "index.js",
   "scripts": {
-    "test": "cpplint --filter='-legal/copyright,-build/header_guard,-build/include,-whitespace/line_length' emscripten_clipboard.h && npm run test:build && node dist/test_clipboard.js",
-    "test:build": "mkdir -p dist && emcc -o dist/test_clipboard.js test/test_clipboard.c",
+    "test": "node dist/test_clipboard.js",
+    "pretest": "npm run build && emcc -o dist/test_clipboard.js test/test_clipboard.c",
     "prebuild": "mkdir -p dist",
     "build": "emcc -o dist/index.html example/main.c",
     "prestart": "npm run build",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "emscripten_clipboard: Clipboard API for Emscripten.",
   "main": "index.js",
   "scripts": {
-    "test": "cpplint --filter='-legal/copyright,-build/header_guard,-build/include,-whitespace/line_length' emscripten_clipboard.h",
+    "test": "cpplint --filter='-legal/copyright,-build/header_guard,-build/include,-whitespace/line_length' emscripten_clipboard.h && npm run test:build && node dist/test_clipboard.js",
+    "test:build": "mkdir -p dist && emcc -o dist/test_clipboard.js test/test_clipboard.c",
     "prebuild": "mkdir -p dist",
     "build": "emcc -o dist/index.html example/main.c",
     "prestart": "npm run build",

--- a/test/test_clipboard.c
+++ b/test/test_clipboard.c
@@ -1,0 +1,67 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#define EMSCRIPTEN_CLIPBOARD_IMPLEMENTATION
+#include "../emscripten_clipboard.h"
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define TEST(name) void test_##name()
+#define RUN(name) do { tests_run++; test_##name(); tests_passed++; printf("PASS: " #name "\n"); } while(0)
+#define ASSERT(cond) do { if (!(cond)) { printf("FAIL: %s\n", #cond); return; } } while(0)
+
+TEST(init_sets_defaults) {
+    emscripten_clipboard clipboard;
+    emscripten_clipboard_init(&clipboard);
+    ASSERT(clipboard.text[0] == '\0');
+    ASSERT(clipboard.user_data == NULL);
+    emscripten_clipboard_deinit(&clipboard);
+}
+
+TEST(deinit_null_safe) {
+    emscripten_clipboard_deinit(NULL);
+}
+
+TEST(deinit_clears_state) {
+    emscripten_clipboard clipboard;
+    emscripten_clipboard_init(&clipboard);
+    emscripten_clipboard_set(&clipboard, "hello");
+    emscripten_clipboard_deinit(&clipboard);
+    ASSERT(clipboard.text[0] == '\0');
+    ASSERT(clipboard.user_data == NULL);
+}
+
+TEST(deinit_allows_reinit) {
+    emscripten_clipboard clipboard;
+    emscripten_clipboard_init(&clipboard);
+    emscripten_clipboard_set(&clipboard, "first");
+    emscripten_clipboard_deinit(&clipboard);
+    emscripten_clipboard_init(&clipboard);
+    ASSERT(clipboard.text[0] == '\0');
+    emscripten_clipboard_deinit(&clipboard);
+}
+
+TEST(get_returns_set_text) {
+    emscripten_clipboard clipboard;
+    emscripten_clipboard_init(&clipboard);
+    emscripten_clipboard_set(&clipboard, "test text");
+    ASSERT(strcmp(emscripten_clipboard_get(&clipboard), "test text") == 0);
+    emscripten_clipboard_deinit(&clipboard);
+}
+
+TEST(get_null_safe) {
+    ASSERT(emscripten_clipboard_get(NULL) == NULL);
+}
+
+int main() {
+    RUN(init_sets_defaults);
+    RUN(deinit_null_safe);
+    RUN(deinit_clears_state);
+    RUN(deinit_allows_reinit);
+    RUN(get_returns_set_text);
+    RUN(get_null_safe);
+    printf("%d/%d tests passed\n", tests_passed, tests_run);
+    return tests_passed == tests_run ? 0 : 1;
+}


### PR DESCRIPTION
Fixes #2

Adds `emscripten_clipboard_deinit()` which removes the `clipboardchange` and `paste` event listeners registered by `emscripten_clipboard_init()`.

The handler reference is stored in `Module._emscripten_clipboard_handlers` keyed by the clipboard pointer so the exact function can be passed to `removeEventListener`.